### PR TITLE
feat: 支持 Android 17 (API 37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 3.9.0 (2026-06-18)
+
+### 新增
+- Android 17（API 37）完整支持：compileSdk / targetSdk 升级至 37
+- 新增网络安全配置文件，显式声明 captive portal 检测域名的明文 HTTP 访问权限
+
+### 变更
+- 升级 AGP 8.13.2 → 9.1.1（Android 17 编译必需）
+- 升级 Gradle Wrapper 9.1.0 → 9.5.1（AGP 9.x 最低要求 9.3.1）
+- 迁移至 AGP 9.x 内置 Kotlin 支持，移除显式 `kotlin-android` 插件声明
+
+---
+
 ## 3.8.5 (2026-02-23)
 
 ### 修复

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 ## 适用范围
 
 - 设备：Pixel Tensor 平台（Pixel 6/7/8/9/10、Fold、Tablet）
-- 系统：Android 13 及以上（建议 Android 14/15/16）
+- 系统：Android 13 及以上（建议 Android 14/15/16/17）
 - 语言：简体中文 / English
 
 ## 构建（开发者）

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Carrier IMS for Pixel (TurboIMS)
-
+  1 +## 3.9.0 (2026-06-18)                                                                                                                                                                                                                                                                                      
+   2 +                                                                                                                                                                                                                                                                                                           
+   3 +### 新增                                                                                                                                                                                                                                                                                                   
+   4 +- Android 17（API 37）完整支持：compileSdk / targetSdk 升级至 37                                                                                                                                                                                                                                           
+   5 +- 新增网络安全配置文件，显式声明 captive portal 检测域名的明文 HTTP 访问权限                                                                                                                                                                                                                               
+   6 +                                                                                                                                                                                                                                                                                                           
+   7 +### 变更                                                                                                                                                                                                                                                                                                   
+   8 +- 升级 AGP 8.13.2 → 9.1.1（Android 17 编译必需）                                                                                                                                                                                                                                                           
+   9 +- 升级 Gradle Wrapper 9.1.0 → 9.5.1（AGP 9.x 最低要求 9.3.1）                                                                                                                                                                                                                                              
+  10 +- 迁移至 AGP 9.x 内置 Kotlin 支持，移除显式 `kotlin-android` 插件声明  
 <p align="center">
   <img src="app/src/main/ic_launcher-playstore.png" width="128" alt="Carrier IMS logo" />
 </p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -66,7 +66,7 @@ Recent improvements include:
 ## Requirements
 
 - Pixel Tensor devices (Pixel 6/7/8/9/10, Fold, Tablet)
-- Android 13+
+- Android 13+ (recommended Android 14/15/16/17)
 - Shizuku running and authorized
 
 ## Build (Developers)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/JetpackSplashTheme">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- 允许 captive portal 检测域名的明文 HTTP 连接 -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">gstatic.cn</domain>
+        <domain includeSubdomains="true">google.cn</domain>
+    </domain-config>
+
+    <!-- 其他域名默认禁止明文流量 -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-agp = "8.13.2"
+agp = "9.1.1"
 kotlin = "2.3.0"
 
-app-version = "3.8.5"
-android-compileSdk = "36"
+app-version = "3.9.0"
+android-compileSdk = "37"
 android-minSdk = "33"
-android-targetSdk = "36"
+android-targetSdk = "37"
 
 hiddenapibypass = "6.1"
 shizuku = "13.1.5"
@@ -39,5 +39,4 @@ material-icons-extended = { group = "androidx.compose.material", name = "materia
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- 升级 AGP 8.13.2 → 9.1.1，Gradle Wrapper 9.1.0 → 9.5.1
- compileSdk/targetSdk 升级至 37，app-version 升至 3.9.0
- 迁移至 AGP 9.x 内置 Kotlin 支持，移除 kotlin-android 插件声明
- 新增 network_security_config.xml 适配 Android 17 明文流量限制
- README 文档补充 Android 17 推荐版本说明
- fix 升级android 17 不可使用的bug