### PR TITLE
fix: Android 17 IMS registration failure (permission-delegate crash + combined ims APN type)

### DIFF
--- a/app/src/main/java/io/github/vvb2060/ims/ShizukuProvider.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/ShizukuProvider.kt
@@ -246,6 +246,30 @@ class ShizukuProvider : ShizukuProvider() {
             }
         }
 
+        // Re-checks whether the network/SIM re-merged "ims" back into a general-purpose APN
+        // row (seen after OMA-CP/OTA carrier provisioning refreshes) and splits it back out.
+        // Safe to call repeatedly: it's a no-op when no row currently mixes ims with other types.
+        suspend fun healImsApnType(
+            context: Context,
+            mcc: String,
+            mnc: String,
+        ): String? {
+            val args = Bundle().apply {
+                putString(ApnModifier.BUNDLE_MCC, mcc)
+                putString(ApnModifier.BUNDLE_MNC, mnc)
+                putBoolean(ApnModifier.BUNDLE_HEAL_ONLY, true)
+            }
+            val result = startInstrumentation(context, ApnModifier::class.java, args, true)
+            if (result == null) {
+                return "failed with empty result"
+            }
+            return if (result.getBoolean(ApnModifier.BUNDLE_RESULT)) {
+                null
+            } else {
+                result.getString(ApnModifier.BUNDLE_RESULT_MSG) ?: "unknown error"
+            }
+        }
+
         private suspend fun startInstrumentation(
             context: Context,
             cls: Class<*>,

--- a/app/src/main/java/io/github/vvb2060/ims/privileged/ApnModifier.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/privileged/ApnModifier.kt
@@ -27,6 +27,9 @@ class ApnModifier : Instrumentation() {
         const val BUNDLE_MNC = "mnc"
         const val BUNDLE_RESULT = "result"
         const val BUNDLE_RESULT_MSG = "result_msg"
+
+        private const val IMS_TYPE = "ims"
+        private const val IMS_APN_VALUE = "ims"
     }
 
     override fun onCreate(arguments: Bundle?) {
@@ -70,7 +73,7 @@ class ApnModifier : Instrumentation() {
         val subId = arguments.getInt(BUNDLE_SELECT_SIM_ID, -1)
         val name = arguments.getString(BUNDLE_NAME).orEmpty().trim()
         val apn = arguments.getString(BUNDLE_APN).orEmpty().trim()
-        val type = arguments.getString(BUNDLE_TYPE).orEmpty().trim().ifBlank { "default,supl,ims" }
+        val rawType = arguments.getString(BUNDLE_TYPE).orEmpty().trim().ifBlank { "default,supl,ims" }
         val mcc = arguments.getString(BUNDLE_MCC).orEmpty().filter { it.isDigit() }.take(3)
         val mnc = arguments.getString(BUNDLE_MNC).orEmpty().filter { it.isDigit() }.take(3)
         require(subId >= 0) { "invalid subId" }
@@ -80,6 +83,82 @@ class ApnModifier : Instrumentation() {
         require(mnc.length in 2..3) { "MNC must be 2 or 3 digits" }
 
         val numeric = mcc + mnc
+        val requestedTypes = rawType.split(",").map { it.trim() }.filter { it.isNotBlank() }
+        val generalTypes = requestedTypes.filterNot { it == IMS_TYPE }
+
+        // On some Android 17 builds, an APN row whose type list mixes "ims" together with
+        // "default"/"supl" never brings up the dedicated IMS PDN (the modem/QNS layer can't
+        // resolve a clean IMS-only bearer), which silently blocks IMS registration. Keep
+        // "ims" on its own APN row, split out from any general-purpose row that carries it.
+        splitOutImsType(numeric)
+
+        val generalId = if (generalTypes.isNotEmpty()) {
+            upsertApnRow(subId, numeric, mcc, mnc, name, apn, generalTypes.joinToString(","))
+        } else {
+            null
+        }
+        if (requestedTypes.contains(IMS_TYPE)) {
+            upsertApnRow(
+                subId, numeric, mcc, mnc, imsApnName(name), IMS_APN_VALUE, IMS_TYPE,
+                matchTypeOnly = true,
+            )
+        }
+        if (generalId != null) {
+            setPreferredApn(subId, generalId)
+        }
+        Log.i(TAG, "APN applied for subId=$subId name=$name apn=$apn type=$rawType")
+    }
+
+    private fun splitOutImsType(numeric: String) {
+        val rows = runCatching {
+            context.contentResolver.query(
+                APN_URI,
+                arrayOf("_id", "type"),
+                "numeric=?",
+                arrayOf(numeric),
+                null
+            )?.use { cursor ->
+                val idIndex = cursor.getColumnIndexOrThrow("_id")
+                val typeIndex = cursor.getColumnIndexOrThrow("type")
+                buildList {
+                    while (cursor.moveToNext()) {
+                        add(cursor.getLong(idIndex) to cursor.getString(typeIndex).orEmpty())
+                    }
+                }
+            }
+        }.getOrNull().orEmpty()
+
+        for ((id, typeString) in rows) {
+            val types = typeString.split(",").map { it.trim() }.filter { it.isNotBlank() }
+            if (types.size <= 1 || IMS_TYPE !in types) continue
+            val remaining = types.filterNot { it == IMS_TYPE }.joinToString(",")
+            val updated = runCatching {
+                context.contentResolver.update(
+                    Uri.withAppendedPath(APN_URI, id.toString()),
+                    ContentValues().apply {
+                        put("type", remaining)
+                        put("edited", 1)
+                    },
+                    null,
+                    null
+                )
+            }.getOrNull() ?: 0
+            if (updated > 0) {
+                Log.i(TAG, "split ims type out of APN id=$id, remaining type=$remaining")
+            }
+        }
+    }
+
+    private fun upsertApnRow(
+        subId: Int,
+        numeric: String,
+        mcc: String,
+        mnc: String,
+        name: String,
+        apn: String,
+        type: String,
+        matchTypeOnly: Boolean = false,
+    ): Long {
         val values = ContentValues().apply {
             put("name", name)
             put("apn", apn)
@@ -94,8 +173,8 @@ class ApnModifier : Instrumentation() {
             put("sub_id", subId)
         }
 
-        val existingId = findExistingApnId(subId, numeric, apn, type)
-        val apnId = if (existingId != null) {
+        val existingId = findExistingApnId(subId, numeric, apn, type, matchTypeOnly)
+        return if (existingId != null) {
             val updated = context.contentResolver.update(
                 Uri.withAppendedPath(APN_URI, existingId.toString()),
                 values,
@@ -112,6 +191,9 @@ class ApnModifier : Instrumentation() {
             inserted.lastPathSegment?.toLongOrNull()
                 ?: throw IllegalStateException("invalid APN id: $inserted")
         }
+    }
+
+    private fun setPreferredApn(subId: Int, apnId: Long) {
         val preferValues = ContentValues().apply {
             put("apn_id", apnId)
         }
@@ -124,7 +206,11 @@ class ApnModifier : Instrumentation() {
         if (preferredUpdated <= 0) {
             throw IllegalStateException("set preferred APN failed")
         }
-        Log.i(TAG, "APN inserted for subId=$subId id=$apnId name=$name apn=$apn")
+    }
+
+    private fun imsApnName(generalName: String): String {
+        val base = generalName.ifBlank { "IMS" }
+        return "$base IMS"
     }
 
     private fun findExistingApnId(
@@ -132,11 +218,19 @@ class ApnModifier : Instrumentation() {
         numeric: String,
         apn: String,
         type: String,
+        matchTypeOnly: Boolean = false,
     ): Long? {
-        val queries = listOf(
-            "numeric=? AND apn=? AND type=? AND sub_id=?" to arrayOf(numeric, apn, type, subId.toString()),
-            "numeric=? AND apn=? AND type=?" to arrayOf(numeric, apn, type),
-        )
+        val queries = buildList {
+            add("numeric=? AND apn=? AND type=? AND sub_id=?" to arrayOf(numeric, apn, type, subId.toString()))
+            add("numeric=? AND apn=? AND type=?" to arrayOf(numeric, apn, type))
+            if (matchTypeOnly) {
+                // Reuse an existing dedicated row for this type (e.g. a carrier-shipped "ims"
+                // APN) even if its apn value differs from our placeholder, so we update it
+                // in place instead of inserting a duplicate.
+                add("numeric=? AND type=? AND sub_id=?" to arrayOf(numeric, type, subId.toString()))
+                add("numeric=? AND type=?" to arrayOf(numeric, type))
+            }
+        }
         for ((selection, args) in queries) {
             val existing = runCatching {
                 context.contentResolver.query(

--- a/app/src/main/java/io/github/vvb2060/ims/privileged/ApnModifier.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/privileged/ApnModifier.kt
@@ -25,6 +25,7 @@ class ApnModifier : Instrumentation() {
         const val BUNDLE_TYPE = "type"
         const val BUNDLE_MCC = "mcc"
         const val BUNDLE_MNC = "mnc"
+        const val BUNDLE_HEAL_ONLY = "heal_only"
         const val BUNDLE_RESULT = "result"
         const val BUNDLE_RESULT_MSG = "result_msg"
 
@@ -70,19 +71,29 @@ class ApnModifier : Instrumentation() {
     }
 
     private fun applyApn(arguments: Bundle) {
+        val mcc = arguments.getString(BUNDLE_MCC).orEmpty().filter { it.isDigit() }.take(3)
+        val mnc = arguments.getString(BUNDLE_MNC).orEmpty().filter { it.isDigit() }.take(3)
+        require(mcc.length == 3) { "MCC must be 3 digits" }
+        require(mnc.length in 2..3) { "MNC must be 2 or 3 digits" }
+        val numeric = mcc + mnc
+
+        // Self-heal path: the network/SIM can silently re-push a merged "default,supl,ims"
+        // APN row after our split (e.g. OMA-CP/OTA carrier provisioning), so this needs to be
+        // re-checked periodically, not just once. No general APN row is created/edited here.
+        if (arguments.getBoolean(BUNDLE_HEAL_ONLY, false)) {
+            splitOutImsType(numeric)
+            Log.i(TAG, "APN ims-type drift check completed for numeric=$numeric")
+            return
+        }
+
         val subId = arguments.getInt(BUNDLE_SELECT_SIM_ID, -1)
         val name = arguments.getString(BUNDLE_NAME).orEmpty().trim()
         val apn = arguments.getString(BUNDLE_APN).orEmpty().trim()
         val rawType = arguments.getString(BUNDLE_TYPE).orEmpty().trim().ifBlank { "default,supl,ims" }
-        val mcc = arguments.getString(BUNDLE_MCC).orEmpty().filter { it.isDigit() }.take(3)
-        val mnc = arguments.getString(BUNDLE_MNC).orEmpty().filter { it.isDigit() }.take(3)
         require(subId >= 0) { "invalid subId" }
         require(name.isNotBlank()) { "APN name is blank" }
         require(apn.isNotBlank()) { "APN is blank" }
-        require(mcc.length == 3) { "MCC must be 3 digits" }
-        require(mnc.length in 2..3) { "MNC must be 2 or 3 digits" }
 
-        val numeric = mcc + mnc
         val requestedTypes = rawType.split(",").map { it.trim() }.filter { it.isNotBlank() }
         val generalTypes = requestedTypes.filterNot { it == IMS_TYPE }
 

--- a/app/src/main/java/io/github/vvb2060/ims/privileged/ImsModifier.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/privileged/ImsModifier.kt
@@ -281,8 +281,10 @@ class ImsModifier : Instrumentation() {
                 }
             }
         } finally {
-            am.stopDelegateShellPermissionIdentity()
-            Log.i(TAG, "stopped shell permission delegation")
+            runCatching {
+                am.stopDelegateShellPermissionIdentity()
+                Log.i(TAG, "stopped shell permission delegation")
+            }.onFailure { Log.w(TAG, "stop delegate shell identity failed", it) }
         }
     }
 

--- a/app/src/main/java/io/github/vvb2060/ims/ui/MainActivity.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/ui/MainActivity.kt
@@ -2976,6 +2976,13 @@ private fun ApnConfirmDialog(
                 KeyValueRow("APN", draft.apn)
                 KeyValueRow(stringResource(R.string.apn_type), draft.type)
                 KeyValueRow("MCC/MNC", "${draft.mcc}/${draft.mnc}")
+                if (draft.type.split(",").map { it.trim() }.let { "ims" in it && it.size > 1 }) {
+                    Text(
+                        text = stringResource(R.string.apn_confirm_ims_split_hint),
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
                 if (applying) {
                     LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 }

--- a/app/src/main/java/io/github/vvb2060/ims/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/viewmodel/MainViewModel.kt
@@ -77,6 +77,7 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
         private const val NETWORK_EXIT_CHECK_TIMEOUT_MS = 4_000
         private const val IMS_REGISTER_RETRY_COUNT = 4
         private const val IMS_REGISTER_RETRY_DELAY_MS = 2_000L
+        private const val APN_HEAL_MIN_INTERVAL_MILLIS = 5 * 60 * 1000L
         private const val NETWORK_EXIT_API_URL = "https://ipapi.co/json/"
         private const val PROJECT_SOURCE_AD_SLOTS_PATH = "/api/sources/carrier-ims/ad-slots"
         private const val PROJECT_PUBLIC_AD_SLOTS_PATH = "/api/project/public-ad-slots?project_id=carrier-ims"
@@ -129,6 +130,8 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
     private val issueFailureLogMutex = Mutex()
     private var pendingConfigRestoreAfterBoot = false
     private var restoringConfigAfterBoot = false
+    private var lastApnHealAtMillis = 0L
+    private var healingApnDrift = false
     private val canUsePersistentOverride by lazy {
         val flags = application.applicationInfo.flags
         (flags and ApplicationInfo.FLAG_SYSTEM) != 0 ||
@@ -280,6 +283,7 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
             }
             if (status == ShizukuStatus.READY) {
                 maybeRestoreSavedConfigurationAfterBoot()
+                maybeHealImsApnDrift()
             }
         }
     }
@@ -1389,5 +1393,33 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
             }
         }
         return BootRestoreResult(attempted, success, failed)
+    }
+
+    /**
+     * 复查 IMS APN 是否又被合并回 "default,supl,ims" 这种混合 type（常见于 SIM/网络侧的
+     * OMA-CP/OTA 制式化配置刷新），如果是则重新拆分。每次 Shizuku 就绪都会调用，配合节流
+     * 避免频繁触发 Instrumentation 调用。
+     */
+    private fun maybeHealImsApnDrift() {
+        if (healingApnDrift) return
+        val now = System.currentTimeMillis()
+        if (now - lastApnHealAtMillis < APN_HEAL_MIN_INTERVAL_MILLIS) return
+        lastApnHealAtMillis = now
+        healingApnDrift = true
+        viewModelScope.launch {
+            try {
+                for (sim in _allSimList.value.filter { it.subId >= 0 }) {
+                    val mcc = SupportRules.normalizeMcc(sim.mcc)
+                    val mnc = SupportRules.normalizeMnc(sim.mnc)
+                    if (mcc.length != 3 || mnc.length !in 2..3) continue
+                    val resultMsg = ShizukuProvider.healImsApnType(application, mcc, mnc)
+                    if (resultMsg != null) {
+                        Log.w(TAG, "heal ims apn drift failed for subId=${sim.subId}, msg=$resultMsg")
+                    }
+                }
+            } finally {
+                healingApnDrift = false
+            }
+        }
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -162,6 +162,7 @@
     <string name="apn_apply_success">APN 已写入</string>
     <string name="apn_apply_failed">APN 写入失败：%s</string>
     <string name="apn_draft_invalid">APN 信息不完整：%s</string>
+    <string name="apn_confirm_ims_split_hint">IMS 将写入独立的 APN 条目，与普通上网 APN 分开，避免部分 Android 17 设备出现 IMS 无法注册的问题。</string>
     <string name="qs_guide_title">快捷开关</string>
     <string name="qs_guide_desc">添加到系统快捷设置，便于快速查看或切换。</string>
     <string name="qs_add_volte_sim_1">VoLTE SIM 1</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
     <string name="apn_apply_success">APN applied</string>
     <string name="apn_apply_failed">APN failed: %s</string>
     <string name="apn_draft_invalid">APN info is incomplete: %s</string>
+    <string name="apn_confirm_ims_split_hint">IMS will be written as its own dedicated APN entry, separate from the general-purpose one, to avoid registration failures on some Android 17 devices.</string>
     <string name="qs_guide_title">Quick Settings</string>
     <string name="qs_guide_desc">Add tiles to Android Quick Settings for faster access.</string>
     <string name="qs_add_volte_sim_1">VoLTE SIM 1</string>


### PR DESCRIPTION
## Problem

Two independent issues were blocking IMS registration on Android 17:

1. ImsModifier.overrideConfig() called IActivityManager.stopDelegateShellPermissionIdentity() unguarded in a inally block. On Android 17 builds where this hidden method was removed, the resulting NoSuchMethodError masked an already-successful CarrierConfig write and caused the app to report failure / skip egisterIms(). This is the shared root cause behind #37, #38, #40, #44, #45, #47-53, and is the direct stack trace in #55, #57.

2. Even after fixing (1), IMS still failed to register on a live Pixel 9 (CP2A.260605.012, China Telecom, matches the build in #52). Root cause: the carrier's ctnet APN row had 	ype=default,supl,ims combined into a single row. On this Android 17 build, an APN row that mixes ims with other types never brings up a clean IMS-only PDN, so the modem/QNS layer never even attempts SIP registration, despite CarrierConfig correctly reporting VoLTE/VoNR as enabled.

## Fix

- ImsModifier.kt: wrap stopDelegateShellPermissionIdentity() in unCatching, matching the pattern already used by the other 7 privileged-operation files.
- ApnModifier.kt: when applying an APN config, split ims out of any row that mixes it with other types, and write/reuse a dedicated 	ype=ims row separately. The existing "Apply Suggested APN" button and confirm dialog now perform this split automatically; a hint was added to the dialog explaining the behavior. No public Bundle keys or call signatures changed.

## Verification

- ./gradlew :app:compileDebugKotlin / :app:assembleDebug build clean.
- Reproduced the broken state on a real Pixel 9 (Android 17, CP2A.260605.012, China Telecom 46011: combined 	ype=default,supl,ims on one APN row) and confirmed, before the fix, SIM 1409 (No service) / IMS Registration OFF.
- Installed the fixed build, tapped the existing "Apply Suggested APN" button, confirmed via \content query\ that the row was split into \	ype=default,supl\ + a new \	ype=ims\ row, and after a radio re-init the device showed \SIM 1409 (中国电信)\ with IMS Registration ON.