### PR TITLE
feat(ims): 新增持久化 VoLTE，重启后无需 Shizuku 即可通话

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 local.properties
 /app/release/
 GEMINI.md
+CLAUDE.md
 .agentdocs
 .claude/
 turboims-debug.keystore

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -130,4 +130,8 @@
         android:name="io.github.vvb2060.ims.privileged.ApnModifier"
         android:label="ApnModifier"
         android:targetPackage="${applicationId}" />
+    <instrumentation
+        android:name="io.github.vvb2060.ims.privileged.PersistentVolteModifier"
+        android:label="PersistentVolteModifier"
+        android:targetPackage="${applicationId}" />
 </manifest>

--- a/app/src/main/java/io/github/vvb2060/ims/ShizukuProvider.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/ShizukuProvider.kt
@@ -19,6 +19,7 @@ import io.github.vvb2060.ims.privileged.ConfigReader
 import io.github.vvb2060.ims.privileged.ImsResetter
 import io.github.vvb2060.ims.privileged.ImsStatusReader
 import io.github.vvb2060.ims.privileged.ImsModifier
+import io.github.vvb2060.ims.privileged.PersistentVolteModifier
 import io.github.vvb2060.ims.privileged.SimReader
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
@@ -174,6 +175,58 @@ class ShizukuProvider : ShizukuProvider() {
                 putBoolean(ImsModifier.BUNDLE_PREFER_PERSISTENT, canUsePersistentOverride)
             }
             return overrideImsConfig(context, bundle)
+        }
+
+        data class PersistentVolteState(
+            val voImsOptIn: Boolean,
+            val advancedCallingEnabled: Boolean,
+            val voNrEnabled: Boolean,
+            val imsRegistered: Boolean,
+        )
+
+        suspend fun queryPersistentVolteState(context: Context, subId: Int): PersistentVolteState? =
+            runPersistentVolte(context, subId, PersistentVolteModifier.ACTION_QUERY).getOrNull()
+
+        suspend fun setPersistentVolteEnabled(
+            context: Context,
+            subId: Int,
+            enable: Boolean,
+        ): Result<PersistentVolteState> = runPersistentVolte(
+            context,
+            subId,
+            if (enable) {
+                PersistentVolteModifier.ACTION_ENABLE
+            } else {
+                PersistentVolteModifier.ACTION_DISABLE
+            }
+        )
+
+        private suspend fun runPersistentVolte(
+            context: Context,
+            subId: Int,
+            action: String,
+        ): Result<PersistentVolteState> {
+            val args = Bundle().apply {
+                putInt(PersistentVolteModifier.BUNDLE_SELECT_SIM_ID, subId)
+                putString(PersistentVolteModifier.BUNDLE_ACTION, action)
+            }
+            val result = startInstrumentation(context, PersistentVolteModifier::class.java, args, true)
+                ?: return Result.failure(IllegalStateException("failed with empty result"))
+            if (!result.getBoolean(PersistentVolteModifier.BUNDLE_RESULT)) {
+                val msg = result.getString(PersistentVolteModifier.BUNDLE_RESULT_MSG)
+                    ?: "unknown error"
+                return Result.failure(IllegalStateException(msg))
+            }
+            return Result.success(
+                PersistentVolteState(
+                    voImsOptIn = result.getInt(PersistentVolteModifier.BUNDLE_VOIMS_OPT_IN, -1) == 1,
+                    advancedCallingEnabled =
+                        result.getBoolean(PersistentVolteModifier.BUNDLE_ADVANCED_CALLING, false),
+                    voNrEnabled = result.getBoolean(PersistentVolteModifier.BUNDLE_VONR, false),
+                    imsRegistered =
+                        result.getBoolean(PersistentVolteModifier.BUNDLE_IMS_REGISTERED, false),
+                )
+            )
         }
 
         suspend fun queryCaptivePortalConfig(context: Context): CaptivePortalConfig? {

--- a/app/src/main/java/io/github/vvb2060/ims/privileged/PersistentVolteModifier.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/privileged/PersistentVolteModifier.kt
@@ -1,0 +1,167 @@
+package io.github.vvb2060.ims.privileged
+
+import android.app.Activity
+import android.app.IActivityManager
+import android.app.Instrumentation
+import android.content.Context
+import android.os.Bundle
+import android.os.ServiceManager
+import android.system.Os
+import android.telephony.TelephonyFrameworkInitializer
+import android.util.Log
+import com.android.internal.telephony.ITelephony
+import rikka.shizuku.ShizukuBinderWrapper
+
+/**
+ * 持久化 VoLTE。
+ *
+ * CarrierConfig 覆盖项（[ImsModifier]）只活在 com.android.phone 进程内存里，重启即失效：
+ * 2026-03 之后的 Pixel 固件在 `CarrierConfigLoader.secureOverrideConfig()` 里加了
+ * `persistent=true only can be invoked by system app` 的校验，非系统应用无解。
+ *
+ * 但是 VoLTE 的开关还有第二条路。固件里的 `ImsManager.isVolteEnabledByPlatform()` 是：
+ *
+ * ```
+ * if (SystemProperties.getInt("persist.dbg.volte_avail_ovr" + phoneId, -1) == 1) return true;
+ * if (SystemProperties.getInt("persist.dbg.volte_avail_ovr", -1) == 1) return true;
+ * if (getLocalImsConfigKeyInt(68) == 1) return true;          // ← 这里
+ * return config_device_volte_available
+ *     && getBooleanCarrierConfig("carrier_volte_available_bool")
+ *     && isGbaValid();
+ * ```
+ *
+ * key 68 是 `ProvisioningManager.KEY_VOIMS_OPT_IN_STATUS`，读的是订阅数据库里的
+ * `voims_opt_in_status` 列——不是 CarrierConfig。它是个短路的 or 条件，直接绕过
+ * `carrier_volte_available_bool`，而且写进数据库后能扛过重启和系统更新。
+ *
+ * 平台开关通了之后还要用户侧开关（`volte_vt_enabled`）也是 1，否则
+ * `isEnhanced4gLteModeSettingEnabledByUser()` 在 voims=1 时会直接返回 `setting == 1`。
+ * 所以这里两个一起写。
+ *
+ * 这些接口只要求 MODIFY_PHONE_STATE，Shizuku 的 shell 身份委派就够；也没有
+ * `overrideConfig` 那种 isShell 拦截。
+ */
+class PersistentVolteModifier : Instrumentation() {
+    companion object {
+        private const val TAG = "PersistentVolteModifier"
+
+        /** ProvisioningManager.KEY_VOIMS_OPT_IN_STATUS */
+        private const val KEY_VOIMS_OPT_IN_STATUS = 68
+
+        const val BUNDLE_SELECT_SIM_ID = "select_sim_id"
+        const val BUNDLE_ACTION = "action"
+        const val BUNDLE_RESULT = "result"
+        const val BUNDLE_RESULT_MSG = "result_msg"
+
+        const val BUNDLE_VOIMS_OPT_IN = "voims_opt_in"
+        const val BUNDLE_ADVANCED_CALLING = "advanced_calling"
+        const val BUNDLE_VONR = "vonr"
+        const val BUNDLE_IMS_REGISTERED = "ims_registered"
+
+        const val ACTION_QUERY = "query"
+        const val ACTION_ENABLE = "enable"
+        const val ACTION_DISABLE = "disable"
+    }
+
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+        if (arguments == null) {
+            finish(Activity.RESULT_CANCELED, Bundle())
+            return
+        }
+
+        val result = Bundle()
+        if (!waitForShizukuBinderReady()) {
+            result.putBoolean(BUNDLE_RESULT, false)
+            result.putString(BUNDLE_RESULT_MSG, "shizuku binder is not ready")
+            finish(Activity.RESULT_OK, result)
+            return
+        }
+
+        val binder = ServiceManager.getService(Context.ACTIVITY_SERVICE)
+        val am = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(binder))
+        var delegated = false
+        try {
+            am.startDelegateShellPermissionIdentity(Os.getuid(), null)
+            delegated = true
+
+            val subId = arguments.getInt(BUNDLE_SELECT_SIM_ID, -1)
+            if (subId < 0) {
+                result.putBoolean(BUNDLE_RESULT, false)
+                result.putString(BUNDLE_RESULT_MSG, "invalid subId")
+                finish(Activity.RESULT_OK, result)
+                return
+            }
+
+            val telephony = ITelephony.Stub.asInterface(
+                ShizukuBinderWrapper(
+                    TelephonyFrameworkInitializer
+                        .getTelephonyServiceManager()
+                        .getTelephonyServiceRegisterer()
+                        .get()!!
+                )
+            )
+
+            when (arguments.getString(BUNDLE_ACTION)) {
+                ACTION_ENABLE -> applyPersistentVolte(telephony, subId, true)
+                ACTION_DISABLE -> applyPersistentVolte(telephony, subId, false)
+            }
+
+            readState(telephony, subId, result)
+            result.putBoolean(BUNDLE_RESULT, true)
+        } catch (t: Throwable) {
+            Log.e(TAG, "persistent volte operation failed", t)
+            result.putBoolean(BUNDLE_RESULT, false)
+            result.putString(BUNDLE_RESULT_MSG, t.message ?: t.javaClass.simpleName)
+        } finally {
+            if (delegated) {
+                runCatching { am.stopDelegateShellPermissionIdentity() }
+                    .onFailure { Log.w(TAG, "stop delegate shell identity failed", it) }
+            }
+        }
+
+        finish(Activity.RESULT_OK, result)
+    }
+
+    @Throws(Exception::class)
+    private fun applyPersistentVolte(telephony: ITelephony, subId: Int, enable: Boolean) {
+        val value = if (enable) 1 else 0
+        Log.i(TAG, "setImsProvisioningInt subId=$subId key=$KEY_VOIMS_OPT_IN_STATUS value=$value")
+        telephony.setImsProvisioningInt(subId, KEY_VOIMS_OPT_IN_STATUS, value)
+
+        if (enable) {
+            // 平台开关放行之后，用户侧开关必须显式为 1：voims=1 时
+            // isEnhanced4gLteModeSettingEnabledByUser() 不再回落到运营商默认值。
+            runCatching { telephony.setAdvancedCallingSettingEnabled(subId, true) }
+                .onFailure { Log.w(TAG, "setAdvancedCallingSettingEnabled failed", it) }
+            // VoNR 用户开关同样落在订阅数据库里，配合 CarrierConfig 恢复后免去二次操作。
+            runCatching { telephony.setVoNrEnabled(subId, true) }
+                .onFailure { Log.w(TAG, "setVoNrEnabled failed", it) }
+        }
+        // 关闭时只回退 voims：用户侧开关留给系统设置里的 VoLTE 开关，
+        // 避免把用户自己设过的值一起清掉。
+    }
+
+    private fun readState(telephony: ITelephony, subId: Int, result: Bundle) {
+        result.putInt(
+            BUNDLE_VOIMS_OPT_IN,
+            runCatching { telephony.getImsProvisioningInt(subId, KEY_VOIMS_OPT_IN_STATUS) }
+                .getOrElse {
+                    Log.w(TAG, "getImsProvisioningInt failed", it)
+                    -1
+                }
+        )
+        result.putBoolean(
+            BUNDLE_ADVANCED_CALLING,
+            runCatching { telephony.isAdvancedCallingSettingEnabled(subId) }.getOrDefault(false)
+        )
+        result.putBoolean(
+            BUNDLE_VONR,
+            runCatching { telephony.isVoNrEnabled(subId) }.getOrDefault(false)
+        )
+        result.putBoolean(
+            BUNDLE_IMS_REGISTERED,
+            runCatching { telephony.isImsRegistered(subId) }.getOrDefault(false)
+        )
+    }
+}

--- a/app/src/main/java/io/github/vvb2060/ims/ui/MainActivity.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/ui/MainActivity.kt
@@ -124,6 +124,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.vvb2060.ims.BuildConfig
 import io.github.vvb2060.ims.R
+import io.github.vvb2060.ims.ShizukuProvider
 import io.github.vvb2060.ims.UpdateApkCleanup
 import io.github.vvb2060.ims.model.Feature
 import io.github.vvb2060.ims.model.FeatureValue
@@ -504,6 +505,10 @@ class MainActivity : BaseActivity() {
         var networkExitChecking by remember { mutableStateOf(false) }
         var networkExitStatus by remember { mutableStateOf<NetworkExitStatus?>(null) }
         var networkExitError by remember { mutableStateOf<String?>(null) }
+        var persistentVolteBusy by remember { mutableStateOf(false) }
+        var persistentVolteState by remember {
+            mutableStateOf<ShizukuProvider.Companion.PersistentVolteState?>(null)
+        }
         var adFreeEnabled by remember { mutableStateOf(viewModel.isAdFreeEnabled()) }
         var commercialAds by remember { mutableStateOf<List<CommercialAd>>(emptyList()) }
         var homeAdToShow by remember { mutableStateOf<CommercialAd?>(null) }
@@ -553,6 +558,14 @@ class MainActivity : BaseActivity() {
             } else {
                 checkingCaptivePortalStatus = false
                 captivePortalFixState = null
+            }
+        }
+        LaunchedEffect(shizukuStatus, selectedSim?.subId) {
+            val subId = selectedSim?.subId ?: -1
+            persistentVolteState = if (shizukuStatus == ShizukuStatus.READY && subId >= 0) {
+                runCatching { viewModel.queryPersistentVolteState(subId) }.getOrNull()
+            } else {
+                null
             }
         }
         LaunchedEffect(Unit) {
@@ -1253,10 +1266,45 @@ class MainActivity : BaseActivity() {
                         networkExitChecking = networkExitChecking,
                         networkExitStatus = networkExitStatus,
                         networkExitError = networkExitError,
+                        persistentVolteState = persistentVolteState,
+                        persistentVolteBusy = persistentVolteBusy,
                         configBackups = configBackups,
                         onSelectSim = { selectedSim = it },
                         onRefreshSimList = refreshSimListAction,
                         onFixCaptivePortal = fixCaptivePortalAction,
+                        onPersistentVolteChange = { enable ->
+                            val sim = extraSelectedSim
+                            if (sim == null || sim.subId < 0) {
+                                Toast.makeText(context, R.string.select_single_sim, Toast.LENGTH_SHORT)
+                                    .show()
+                                return@ExtraToolsPage
+                            }
+                            if (persistentVolteBusy) return@ExtraToolsPage
+                            scope.launch {
+                                persistentVolteBusy = true
+                                val result = viewModel.setPersistentVolteEnabled(sim.subId, enable)
+                                result
+                                    .onSuccess {
+                                        persistentVolteState = it
+                                        Toast.makeText(
+                                            context,
+                                            R.string.persistent_volte_applied,
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    }
+                                    .onFailure {
+                                        Toast.makeText(
+                                            context,
+                                            context.getString(
+                                                R.string.persistent_volte_failed,
+                                                it.message ?: it.javaClass.simpleName
+                                            ),
+                                            Toast.LENGTH_LONG
+                                        ).show()
+                                    }
+                                persistentVolteBusy = false
+                            }
+                        },
                         onTikTokFixChange = { enabled ->
                             handleFeatureSwitchChange(
                                 extraSelectedSim,
@@ -1880,10 +1928,13 @@ private fun ExtraToolsPage(
     networkExitChecking: Boolean,
     networkExitStatus: NetworkExitStatus?,
     networkExitError: String?,
+    persistentVolteState: ShizukuProvider.Companion.PersistentVolteState?,
+    persistentVolteBusy: Boolean,
     configBackups: List<ConfigBackupSnapshot>,
     onSelectSim: (SimSelection) -> Unit,
     onRefreshSimList: () -> Unit,
     onFixCaptivePortal: () -> Unit,
+    onPersistentVolteChange: (Boolean) -> Unit,
     onTikTokFixChange: (Boolean) -> Unit,
     onCheckNetworkExit: () -> Unit,
     onOpenApnSettings: () -> Unit,
@@ -1928,6 +1979,14 @@ private fun ExtraToolsPage(
         status = networkExitStatus,
         error = networkExitError,
         onCheck = onCheckNetworkExit,
+    )
+    PersistentVolteCard(
+        state = persistentVolteState,
+        busy = persistentVolteBusy,
+        switchEnabled = shizukuStatus == ShizukuStatus.READY &&
+            !persistentVolteBusy &&
+            (selectedSim?.subId ?: -1) >= 0,
+        onCheckedChange = onPersistentVolteChange,
     )
     TiktokFixCard(
         enabled = tiktokEnabled,
@@ -1989,6 +2048,76 @@ private fun RegionCompatibilityCard(
                         R.string.region_status_not_applicable
                     }
                 ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PersistentVolteCard(
+    state: ShizukuProvider.Companion.PersistentVolteState?,
+    busy: Boolean,
+    switchEnabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 16.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            BooleanFeatureItem(
+                title = stringResource(R.string.persistent_volte),
+                description = stringResource(R.string.persistent_volte_desc),
+                checked = state?.voImsOptIn == true,
+                enabled = switchEnabled,
+                onCheckedChange = onCheckedChange,
+            )
+            if (busy) {
+                Text(
+                    text = stringResource(R.string.persistent_volte_applying),
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            if (state != null) {
+                KeyValueRow(
+                    stringResource(R.string.persistent_volte_platform_gate),
+                    stringResource(
+                        if (state.voImsOptIn) R.string.region_status_yes else R.string.region_status_no
+                    ),
+                )
+                KeyValueRow(
+                    stringResource(R.string.persistent_volte_user_switch),
+                    stringResource(
+                        if (state.advancedCallingEnabled) {
+                            R.string.region_status_yes
+                        } else {
+                            R.string.region_status_no
+                        }
+                    ),
+                )
+                KeyValueRow(
+                    stringResource(R.string.vonr),
+                    stringResource(
+                        if (state.voNrEnabled) R.string.region_status_yes else R.string.region_status_no
+                    ),
+                )
+                KeyValueRow(
+                    stringResource(R.string.persistent_volte_ims_registered),
+                    stringResource(
+                        if (state.imsRegistered) R.string.region_status_yes else R.string.region_status_no
+                    ),
+                )
+            }
+            Text(
+                text = stringResource(R.string.persistent_volte_note),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.outline,
             )
         }
     }

--- a/app/src/main/java/io/github/vvb2060/ims/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/viewmodel/MainViewModel.kt
@@ -602,6 +602,30 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
         )
     }
 
+    suspend fun queryPersistentVolteState(subId: Int): ShizukuProvider.Companion.PersistentVolteState? {
+        if (subId < 0) return null
+        return ShizukuProvider.queryPersistentVolteState(application, subId)
+    }
+
+    suspend fun setPersistentVolteEnabled(
+        subId: Int,
+        enable: Boolean,
+    ): Result<ShizukuProvider.Companion.PersistentVolteState> {
+        if (subId < 0) {
+            return Result.failure(IllegalArgumentException("invalid subId"))
+        }
+        val result = ShizukuProvider.setPersistentVolteEnabled(application, subId, enable)
+        result.exceptionOrNull()?.let {
+            appendSwitchFailureLog(
+                action = "PERSISTENT_VOLTE",
+                subId = subId,
+                stage = if (enable) "enable" else "disable",
+                backendMessage = it.message ?: it.javaClass.simpleName
+            )
+        }
+        return result
+    }
+
     fun isDodopaySupportConfigured(): Boolean = dodopaySupportUrlTemplate != null
 
     fun isDodopaySupportFeedConfigured(): Boolean = dodopaySupportFeedUrl != null

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -133,6 +133,15 @@
     <string name="tiktok_network_fix">修复 TikTok 无网络</string>
     <string name="tiktok_network_fix_desc">仅大陆SIM有此选项，海外SIM无需修复</string>
     <string name="tiktok_network_fix_unavailable">仅大陆 SIM 适用</string>
+    <string name="persistent_volte">持久化 VoLTE</string>
+    <string name="persistent_volte_desc">重启后不用 Shizuku 也能打电话。把 VoIMS opt-in 标志写进订阅数据库，不走 CarrierConfig，所以重启不会被清掉。</string>
+    <string name="persistent_volte_applying">正在写入…</string>
+    <string name="persistent_volte_applied">已写入，重启后依然有效</string>
+    <string name="persistent_volte_failed">失败：%s</string>
+    <string name="persistent_volte_platform_gate">VoIMS opt-in（平台开关）</string>
+    <string name="persistent_volte_user_switch">VoLTE 用户开关</string>
+    <string name="persistent_volte_ims_registered">IMS 已注册</string>
+    <string name="persistent_volte_note">只保通话。5G SA 仍依赖首页的 CarrierConfig 开关，每次重启都会失效。</string>
     <string name="extra_requires_shizuku_title">需要 Shizuku</string>
     <string name="region_compat_title">区域兼容状态</string>
     <string name="region_mainland_sim">大陆 SIM</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,15 @@
     <string name="tiktok_network_fix">Fix TikTok No Network</string>
     <string name="tiktok_network_fix_desc">Domestic SIM only: ON uses random numeric ISO; OFF restores country ISO by SIM home profile.</string>
     <string name="tiktok_network_fix_unavailable">Available only for mainland China SIMs.</string>
+    <string name="persistent_volte">Persistent VoLTE</string>
+    <string name="persistent_volte_desc">Keeps VoLTE working after a reboot without Shizuku. Writes the VoIMS opt-in flag to the subscription database instead of CarrierConfig, so it is not wiped on restart.</string>
+    <string name="persistent_volte_applying">Applying…</string>
+    <string name="persistent_volte_applied">Applied. This survives reboots.</string>
+    <string name="persistent_volte_failed">Failed: %s</string>
+    <string name="persistent_volte_platform_gate">VoIMS opt-in (platform gate)</string>
+    <string name="persistent_volte_user_switch">VoLTE user switch</string>
+    <string name="persistent_volte_ims_registered">IMS registered</string>
+    <string name="persistent_volte_note">Only covers calls. 5G SA still needs the CarrierConfig switches on the home page, which reset on every reboot.</string>
     <string name="extra_requires_shizuku_title">Shizuku required</string>
     <string name="region_compat_title">Region Compatibility</string>
     <string name="region_mainland_sim">Mainland SIM</string>

--- a/stub/src/main/java/com/android/internal/telephony/ITelephony.java
+++ b/stub/src/main/java/com/android/internal/telephony/ITelephony.java
@@ -20,6 +20,14 @@ public interface ITelephony extends android.os.IInterface {
 
     int getImsProvisioningInt(int subId, int key);
 
+    void setAdvancedCallingSettingEnabled(int subId, boolean isEnabled);
+
+    boolean isAdvancedCallingSettingEnabled(int subId);
+
+    int setVoNrEnabled(int subId, boolean enabled);
+
+    boolean isVoNrEnabled(int subId);
+
     void resetIms(int slotIndex);
 
     boolean isImsRegistered(int subId);


### PR DESCRIPTION
## 背景

从 2026-03 之后的 Pixel 固件开始，`ImsModifier` 写下去的 CarrierConfig 覆盖项在重启后一定丢失。原因在 `com.android.phone` 的 `CarrierConfigLoader` 里新增了一个私有方法 `secureOverrideConfig()`，它在每次 `overrideConfig` 之前执行：

```java
if (TelephonyPermissions.isShell(getCallingUid()))
    throw new SecurityException("overrideConfig cannot be invoked by shell");
if (persistent && isUserBuild() && !isSystemApp())
    throw new SecurityException("overrideConfig with persistent=true only can be invoked by system app");
```

`isSystemApp()` 取调用方包名再查 `FLAG_SYSTEM | FLAG_UPDATED_SYSTEM_APP`，侧载安装的应用永远过不了。所以目前仓库里 `canUsePersistentOverride`（`MainViewModel.kt`）判断出来一定是 false，`persistent=true` 分支和 `BrokerInstrumentation` 的重试兜底在正常安装下都是死代码。`adb shell cmd phone cc` 也被单独限制在 debuggable 版本（`cc: Permission denied`），没有绕过的余地。

实机确认（Pixel 9 Pro XL / komodo，Android 16 `CP1A.260305.018`）：`dumpsys carrier_config` 里 24 次 `overrideConfig` 调用全部是 `persistent=false`，`mPersistentOverrideConfigs` 两个卡槽都是 null。

## 思路

VoLTE 还有第二条路。`/system/framework/ims-common.jar` 里 `ImsManager.isVolteEnabledByPlatform()` 反编译出来是：

```java
if (SystemProperties.getInt("persist.dbg.volte_avail_ovr" + phoneId, -1) == 1) return true;
if (SystemProperties.getInt("persist.dbg.volte_avail_ovr", -1) == 1) return true;
if (getLocalImsConfigKeyInt(68) == 1) return true;          // ← 这里短路
return config_device_volte_available
    && getBooleanCarrierConfig("carrier_volte_available_bool")
    && isGbaValid();
```

key 68 是 `ProvisioningManager.KEY_VOIMS_OPT_IN_STATUS`，`getLocalImsConfigKeyInt(68)` 内部调 `isVoImsOptInEnabled()`，读的是订阅数据库的 `voims_opt_in_status` 列（`SubscriptionDatabaseManager.setVoImsOptInEnabled`），不是 CarrierConfig。这是一个短路的 or 条件，直接跳过 `carrier_volte_available_bool`，而且数据库能扛过重启和系统更新。

前两个 `persist.dbg.*` 在 SELinux 里是 `telephony_config_prop`，shell 上下文写不了（实测 `Failed to set property`），所以只有 key 68 这条路走得通。

`setImsProvisioningInt` 只要求 `MODIFY_PHONE_STATE`，Shizuku 的 shell 身份委派够用，而且它没有 `overrideConfig` 那种 `isShell` 拦截。

## 改动

- `stub/ITelephony.java` 补充 `setAdvancedCallingSettingEnabled` / `isAdvancedCallingSettingEnabled` / `setVoNrEnabled` / `isVoNrEnabled`。签名是从设备 `framework.jar` 的 `ITelephony$Stub` 里读出来对齐的（`(IZ)V`、`(I)Z`、`(IZ)I`、`(I)Z`），不是猜的。
- 新增 `privileged/PersistentVolteModifier.kt`，沿用现有 instrumentation + `startDelegateShellPermissionIdentity` 的写法，一次写入 VoIMS opt-in、VoLTE 用户开关和 VoNR，并回读状态。
- `ShizukuProvider` 增加 `setPersistentVolteEnabled` / `queryPersistentVolteState`。
- 附加功能页新增「持久化 VoLTE」卡片，开关 + 回显平台开关 / 用户开关 / VoNR / IMS 注册状态。
- 中英文案齐全（`values` 和 `values-zh-rCN`）。

### 一个必须注意的坑

`voims_opt_in_status` 置 1 之后，`isEnhanced4gLteModeSettingEnabledByUser()` 的行为会变。反编译出来是：

```java
boolean notConfigurable = !editable || hidden;
boolean uninitialized   = (setting == -1);
if (notConfigurable || uninitialized) {
    if (!isVoImsOptInEnabled()) return onByDefault;   // 回落到运营商默认值
}
return (setting == 1);
```

原状态是 `volte_vt_enabled = -1`、voims = 0，走的是「回落到 `enhanced_4g_lte_on_by_default_bool`」，平台默认 true，所以用户开关其实是开的。一旦只把 voims 设成 1，这个回落分支就不走了，直接返回 `setting == 1`，而 `setting` 还是 -1，结果反而变成关。

也就是说**单独打开 VoIMS opt-in 会让 VoLTE 比改之前更差**。所以 `PersistentVolteModifier` 在 enable 时一定同时写 `setAdvancedCallingSettingEnabled(true)`，这两个不能拆开。这个坑我踩过一次，代码和注释里都标了。

关闭时只回退 voims，不动用户侧开关，避免把用户自己在系统设置里设过的值一起清掉。

## 验证

Pixel 9 Pro XL，Android 16 `CP1A.260305.018`，锁 bootloader、未 root，中国移动实体卡（subId 2）。用页面上的开关写入后重启，全程不解锁、不开 App：

```
boot_count          : 457 → 458
keyguard            : isKeyguardShowing=true     ← 始终没解锁
carrier overrides   : 两个卡槽 mOverrideConfigs 都是 null
carrier_volte_available_bool 在 phone 0 配置里不存在 → 平台默认 false
isVoImsOptInEnabled     = 1
isEnhanced4GModeEnabled = 1
isImsRegistered(2)      = 1
availableServices=[VOICE,SMS,VIDEO] on LTE
```

在完全没有 CarrierConfig 覆盖、`carrier_volte_available_bool` 为默认 false 的情况下 IMS 正常注册，说明确实是走的 key 68 这条短路。连续三次重启结果一致。开关本身的写入也在 logcat 里确认过：

```
PersistentVolteModifier: setImsProvisioningInt subId=2 key=68 value=0   // 关
PersistentVolteModifier: setImsProvisioningInt subId=2 key=68 value=1   // 开
```

数据库列同步变化。

## 不在本 PR 范围内

5G **SA** 没法用同样的办法持久化。`carrier_nr_availabilities_int_array` 只存在于 CarrierConfig，订阅数据库里没有对应列，也没有 key 68 那样的短路条件。Google 下发的 `chinamobile_cn` 配置每次开机给的是 `[1]`（只有 NSA），SA 需要 `[1, 2]`，重启必然回退。所以卡片文案里写清楚了「只保通话」。

顺带一提，覆盖下发之后 modem 经常还停在 LTE，要等重新附着或者切一次飞行模式才会上 SA。

## 兼容性

- 事务号是随固件变的，代码里没有硬编码事务号，走的是 `ITelephony` 接口调用，所以 OTA 之后不需要跟着改。
- 老固件上 `overrideConfig(persistent=true)` 还能用的话，原有逻辑不受影响，这个开关是并行的另一条路，不冲突。
- 目标机型之外（非 Tensor / 非 Pixel）没测过。

## 备注

我在中国大陆用这台机器，主卡是移动，这个问题对我来说是刚需——手机没电重启之后在没有 Wi-Fi 的地方连电话都打不出去。所以优先解决了通话，5G 那部分只能等有 Wi-Fi 重新下发。

如果需要补 CHANGELOG 条目，请告诉我版本号该挂在哪个版本下，我再补一个 commit。
